### PR TITLE
Do not show download messages by default

### DIFF
--- a/spacy_udpipe/utils.py
+++ b/spacy_udpipe/utils.py
@@ -26,7 +26,7 @@ def _check_models_dir(lang: str) -> None:
     assert os.path.exists(MODELS_DIR), "Download the pretrained model(s) first"
 
 
-def download(lang: str) -> None:
+def download(lang: str, verbose: bool = False) -> None:
     """Download the UDPipe pretrained model.
 
     lang: ISO 639-1 language code or shorthand UDPipe model name.
@@ -37,12 +37,15 @@ def download(lang: str) -> None:
     except AssertionError:
         os.makedirs(MODELS_DIR)
     if LANGUAGES[lang] in os.listdir(MODELS_DIR):
-        print(f"Already downloaded a model for the '{lang}' language")
+        if verbose:
+            print(f"Already downloaded a model for the '{lang}' language")
         return
     url = f"{BASE_URL}/{LANGUAGES[lang]}"
     filename = os.path.join(MODELS_DIR, LANGUAGES[lang])
     urllib.request.urlretrieve(url=url, filename=filename)
-    print(f"Downloaded pre-trained UDPipe model for '{lang}' language")
+    
+    if verbose:
+        print(f"Downloaded pre-trained UDPipe model for '{lang}' language")
 
 
 def get_path(lang: str) -> str:

--- a/spacy_udpipe/utils.py
+++ b/spacy_udpipe/utils.py
@@ -43,7 +43,6 @@ def download(lang: str, verbose: bool = False) -> None:
     url = f"{BASE_URL}/{LANGUAGES[lang]}"
     filename = os.path.join(MODELS_DIR, LANGUAGES[lang])
     urllib.request.urlretrieve(url=url, filename=filename)
-    
     if verbose:
         print(f"Downloaded pre-trained UDPipe model for '{lang}' language")
 


### PR DESCRIPTION
Currently, when you have a setup as follows:

```python
def get_parser(lang: str):
    spacy_udpipe.download(lang)
    nlp = spacy_udpipe.load(lang)
```

this will always print out a message, whether it downloaded the model or whether it is already present. I would be useful if this behaviour can be controlled by the user. I added a `verbose` flag to the download method, which is False by default.

In my specific case, I have the above workflow, but I also write other things to STDOUT. If a user wants to pipe that to a file, it will always have the spacy-udpipe download message at the top - which is not desired.