### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:

--- a/spacy_udpipe/tokenizer.py
+++ b/spacy_udpipe/tokenizer.py
@@ -6,7 +6,7 @@ from spacy.vocab import Vocab
 from spacy.util import registry
 from ufal.udpipe import Sentence, Word
 
-from .udpipe import NO_SPACE, UDPipeModel
+from .udpipe import UDPipeModel
 from .utils import get_path
 
 
@@ -40,7 +40,7 @@ def _spacy_dep(d: str) -> str:
     return d.upper() if d == "root" else d
 
 
-class UDPipeTokenizer(object):
+class UDPipeTokenizer:
     """Custom Tokenizer which sets all the attributes because
     the UDPipe pipeline runs only once and does not
     contain separate spaCy pipeline components.
@@ -97,7 +97,7 @@ class UDPipeTokenizer(object):
             text = ""
             for token in tokens:
                 text += token.form
-                if NO_SPACE not in token.misc:
+                if token.getSpaceAfter():
                     text += " "
         for i, token in enumerate(tokens):
             span = text[offset:]
@@ -117,7 +117,7 @@ class UDPipeTokenizer(object):
             lemmas.append(token.lemma or "")
             offset += len(token.form)
             span = text[offset:]
-            if i == len(tokens) - 1 or NO_SPACE in token.misc:
+            if i == len(tokens) - 1 or not token.getSpaceAfter():
                 spaces.append(False)
             elif not is_aligned:
                 spaces.append(True)

--- a/spacy_udpipe/udpipe.py
+++ b/spacy_udpipe/udpipe.py
@@ -81,7 +81,9 @@ class UDPipeModel:
         self.model = Model.load(path)
         self._lang = lang.split("-")[0]
         self._path = path
-        self._meta = meta or _default_model_meta(self._lang, self._path.split("/")[-1])
+        self._meta = meta or _default_model_meta(
+            self._lang, self._path.split("/")[-1]
+        )
 
     def __reduce__(self):
         # required for multiprocessing on Windows

--- a/spacy_udpipe/udpipe.py
+++ b/spacy_udpipe/udpipe.py
@@ -3,14 +3,30 @@ from typing import Dict, List, Optional, Union
 
 from ufal.udpipe import InputFormat
 from ufal.udpipe import Model
-from ufal.udpipe import OutputFormat, ProcessingError, Sentence, Word
+from ufal.udpipe import OutputFormat, ProcessingError, Sentence
 
 from .utils import get_path
 
-NO_SPACE = "SpaceAfter=No"
+
+def _default_model_meta(lang: str, name: str) -> Dict:
+    return {
+        "author": "Milan Straka & Jana Straková",
+        "description": "UDPipe pretrained model.",
+        "email": "straka@ufal.mff.cuni.cz",
+        "lang": f"udpipe_{lang}",
+        "license": "CC BY-NC-SA 4.0",
+        "name": name,
+        "parent_package": "spacy_udpipe",
+        "pipeline": [
+            "Tokenizer", "Tagger", "Lemmatizer", "Parser"
+        ],
+        "source": "Universal Dependencies 2.5",
+        "url": "http://ufal.mff.cuni.cz/udpipe",
+        "version": "1.2.0"
+    }
 
 
-class PretokenizedInputFormat(object):
+class PretokenizedInputFormat:
     """Dummy tokenizer for pretokenized input.
 
     Execution speed might be slow compared to other UDPipe tokenizers
@@ -35,19 +51,19 @@ class PretokenizedInputFormat(object):
             line = next(self.lines)
         except StopIteration:
             return False
+
         tokens = line.split("\t")
-        prev_word = Word()
-        for token in tokens:
+        num_tokens = len(tokens)
+        for i, token in enumerate(tokens):
             word = sentence.addWord(token)
-            if re.match(r"\W", token):
-                # leave no space after previous token iff current token
+            if i < num_tokens - 1 and re.match(r"\W", tokens[i + 1]):
+                # leave no space after current token iff next token
                 # is non-alphanumeric (i.e. punctuation)
-                prev_word.misc = NO_SPACE
-            prev_word = word
+                word.setSpaceAfter(False)
         return True
 
 
-class UDPipeModel(object):
+class UDPipeModel:
 
     def __init__(
         self,
@@ -64,20 +80,12 @@ class UDPipeModel(object):
         path = path or get_path(lang=lang)
         self.model = Model.load(path)
         self._lang = lang.split("-")[0]
-        self._meta = meta or {"author": "Milan Straka & Jana Straková",
-                              "description": "UDPipe pretrained model.",
-                              "email": "straka@ufal.mff.cuni.cz",
-                              "lang": f"udpipe_{self._lang}",
-                              "license": "CC BY-NC-SA 4.0",
-                              "name": path.split("/")[-1],
-                              "parent_package": "spacy_udpipe",
-                              "pipeline": [
-                                  "Tokenizer", "Tagger", "Lemmatizer", "Parser"
-                              ],
-                              "source": "Universal Dependencies 2.5",
-                              "url": "http://ufal.mff.cuni.cz/udpipe",
-                              "version": "1.2.0"
-                              }
+        self._path = path
+        self._meta = meta or _default_model_meta(self._lang, self._path.split("/")[-1])
+
+    def __reduce__(self):
+        # required for multiprocessing on Windows
+        return self.__class__, (self._lang, self._path, self._meta)
 
     def __call__(
         self,


### PR DESCRIPTION
This PR makes necessary changes in the codebase to fix 2 failing tests on Windows (`tests/test_spacy_udpipe.py::test_pipe` and `tests/languages/en/test_en_language.py::test_spacy_udpipe_pretokenized`) and improves style.

Changes:

* adds the `__reduce__` dunder to `UDPipeModel` for `nlp.pipe` support on Windows
* uses `Word.setSpaceAfter` to set the `misc` field instead of manually setting it (`word.misc = "SpaceAfter=No"`)
* removes unnecessary "inherit from object" from class declarations
